### PR TITLE
Remove 'Tables' from the form and from JS code.

### DIFF
--- a/static/scripts.js
+++ b/static/scripts.js
@@ -85,7 +85,6 @@ function loadDoc(url, cFunction) {
 
       var data = JSON.stringify({
         "query": document.getElementById("query").value,
-        'tables': document.getElementById("tables").value,
         'columns': document.getElementById("columns").value
       });
       xhttp.open("POST", url, true);

--- a/templates/ajax_test.html
+++ b/templates/ajax_test.html
@@ -20,9 +20,6 @@
     <label>Search for</label>
     <input class="in_query" type="text" id="query" placeholder="Text to find or regular expression" />
     <br />
-    <label>Table(s)</label>
-    <input class="in_tables" type="text" id="tables" placeholder="Tables to show in results, empty means all" />
-    <br />
     <label>Column(s)</label>
     <input class="in_columns" type="text" id="columns" placeholder="Columns to show in results, empty means all" />
     <br />


### PR DESCRIPTION
All tables are searched and display column names are qualified by table name.